### PR TITLE
Add FastAPI microservice README template

### DIFF
--- a/service/README.md
+++ b/service/README.md
@@ -1,0 +1,76 @@
+# FastAPI Microservice
+
+## Purpose
+A FastAPI-based microservice for [Project Name]. This service exposes RESTful endpoints and can be combined with other microservices or a web frontend.
+Replace `[Project Name]` with the name of your application throughout this file. Add or remove sections as the project structure becomes clear.
+
+## Features
+- Asynchronous Python runtime
+- `uvicorn` development server
+- Pydantic models for request and response validation
+- Dependency injection using `Depends`
+- Optional SQLAlchemy integration
+- Environment-based settings with Pydantic `BaseSettings`
+- Automatic OpenAPI docs available at `/docs`
+- Health and readiness endpoints
+- Dockerfile and Docker Compose setup
+- Unit tests with `pytest`
+
+## Getting Started
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Copy `.env.example` to `.env` and configure environment variables (database URL, secrets, etc.).
+3. Run the application with `uvicorn app.main:app --reload`.
+4. Execute the tests using `pytest`.
+5. Lint and format the code with your preferred tools (`ruff`, `black`, etc.).
+
+## API Endpoints
+Document your API here once routes are defined.
+
+| Method | Path    | Description    |
+|--------|---------|----------------|
+| GET    | /health | Liveness probe |
+| GET    | /ready  | Readiness probe|
+
+## Directory Structure
+```
+service/
+├── app/
+│   ├── api/              # Route definitions
+│   ├── core/             # Configuration and setup
+│   ├── models/           # Pydantic models
+│   ├── services/         # Business logic
+│   ├── main.py           # FastAPI application
+│   └── __init__.py
+├── tests/                # pytest test cases
+├── Dockerfile
+└── requirements.txt
+```
+
+## Non-Functional Requirements
+- Code must pass linting and formatting checks before commit.
+- Provide unit tests for critical paths.
+- Ensure container builds succeed under CI.
+- Expose OpenAPI schema for integrations.
+
+## Global Standards
+
+### Security Standards
+- Use `.env` files for secrets and never check them into source control.
+- Recommend dependency scanning (`pip-audit`).
+- Implement authentication and authorization if required.
+- Enforce HTTPS and secure headers when deployed.
+
+### Logging Specifications
+- Use structured JSON logging.
+- Define log levels (`DEBUG`, `INFO`, `WARNING`, `ERROR`).
+- Provide centralized logging support (e.g., Fluentd, Loki, or the ELK stack).
+
+### Error Handling
+- Return a consistent error schema: `{"error_code": "...", "message": "...", "details": {...}}`.
+- Provide sample responses for common failure scenarios.
+- Include retry/backoff logic where appropriate.
+
+## Customization Notes
+- Update the API table with your actual endpoints.
+- Expand the directory structure section as the project grows.
+- Add deployment instructions (Docker, Kubernetes, etc.) as needed.


### PR DESCRIPTION
## Summary
- add `service/README.md` documenting a template for FastAPI-based microservices

## Testing
- `git status --short`