### PR TITLE
Add LangChain configuration template

### DIFF
--- a/agent-langchain/README.md
+++ b/agent-langchain/README.md
@@ -1,0 +1,58 @@
+# LangChain Configuration
+
+## Purpose
+A configuration template for [Project Name] built using **LangChain**. This guide outlines best practices for defining chains, prompts, and integrations. Replace `[Project Name]` with the name of your application.
+
+## Features
+- Modular chains that combine prompts, tools, and memory
+- Support for multiple LLM providers (OpenAI, Azure, Cohere, etc.)
+- Environment-based settings for API keys and endpoints
+- Built-in callbacks for logging and tracing
+- Example evaluations for prompt/response quality
+- Guidelines for secure secret management
+
+## Getting Started
+1. Install dependencies with `pip install -r requirements.txt`.
+2. Place configuration files under `configs/` in YAML or JSON format.
+3. Set API keys in your `.env` file or secrets manager.
+4. Load the configuration in your app and initialize LangChain components.
+5. Run automated tests to validate chain behavior.
+
+## Configuration Guidelines
+- Clearly document each chain's role and its expected inputs/outputs.
+- Keep prompts in separate files when they grow large.
+- Parameterize secrets using environment variables.
+- Include comments for complex tool or memory usage.
+- Validate your configuration with unit tests and schema checks.
+
+## Directory Structure
+```
+agent-langchain/
+├── configs/        # LangChain configuration files
+└── README.md       # This template
+```
+
+## Non-Functional Requirements
+- Configuration files must be linted and validated before commit.
+- Provide tests ensuring chains respond correctly given sample inputs.
+- Run validation and unit tests in CI prior to merging changes.
+
+## Global Standards
+
+### Security Standards
+- Never commit API keys or credentials into configuration files.
+- Store secrets in environment variables or a secure secrets manager.
+- Restrict read/write permissions on configuration files.
+
+### Logging Specifications
+- Enable callbacks for structured logging of chain execution.
+- Aggregate logs centrally for debugging and analysis.
+
+### Error Handling
+- Provide fallback responses when LLM requests fail.
+- Document retry logic for external API calls.
+
+## Customization Notes
+- Extend the features section with domain-specific chains or tools.
+- Update the directory structure as your project evolves.
+- Document how your application loads and runs these LangChain configs.


### PR DESCRIPTION
## Summary
- add `agent-langchain/README.md` template for LangChain best practices

## Testing
- `pytest -q` *(fails: command not found)*